### PR TITLE
New autoload hf

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -9,6 +9,7 @@ import json
 import logging
 import tempfile
 import textwrap
+import warnings
 from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
@@ -69,6 +70,10 @@ class HuggingFaceModel(ComposerModel):
         self.model = model
         self.config = model.config
         self.tokenizer = tokenizer
+
+        if self.tokenizer is None:
+            warnings.warn(
+                'The tokenizer was not provided. This means the tokenizer config will not be saved in the checkpoint.')
 
         if tokenizer is not None and self.config.vocab_size != len(tokenizer):
             # set model's word embedding matrix and final lm_head to vocab size according to tokenizer

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -115,6 +115,8 @@ class HuggingFaceModel(ComposerModel):
         Returns:
             Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]: The loaded huggingface model and (if present) tokenizer
         """
+        import transformers
+
         # default local path to a tempfile if path is not provided
         if local_checkpoint_save_location is None:
             tmp_dir = tempfile.TemporaryDirectory()
@@ -151,7 +153,7 @@ class HuggingFaceModel(ComposerModel):
         else:
             # If the instantiation class is not explicitly provided, attempt to import the saved class and use it
             try:
-                saved_class = import_object(hf_model_state['config']['content'])
+                saved_class = import_object(':'.join(hf_model_state['config']['class'].rsplit('.', maxsplit=1)))
             except (ModuleNotFoundError, AttributeError):
                 raise ValueError(
                     textwrap.dedent(

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -105,46 +105,40 @@ class HuggingFaceModel(ComposerModel):
     ) -> Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]:
         """Loads a HuggingFace model (and tokenizer if present) from a composer checkpoint.
 
-        .. testsetup:: composer.models.huggingface.HuggingFaceModel.hf_from_composer_checkpoint
+        Example:
+
+        .. testsetup::hf_from_composer_checkpoint
+
+            import torch
+
+            dataset = RandomTextClassificationDataset(size=16, use_keys=True)
+            train_dataloader = torch.utils.data.DataLoader(dataset, batch_size=8)
+            eval_dataloader = torch.utils.data.DataLoader(dataset, batch_size=8)
 
             import transformers
             from composer.models import HuggingFaceModel
             from composer.trainer import Trainer
-            from tests.common.datasets import RandomTextClassificationDataset
 
             hf_model = transformers.AutoModelForSequenceClassification.from_pretrained('prajjwal1/bert-tiny', num_labels=2)
             hf_tokenizer = transformers.AutoTokenizer.from_pretrained('prajjwal1/bert-tiny')
-            model = HuggingFaceModel(hf_model, tokenizer=hf_tokenizer, metrics=[], use_logits=True)
-
-            vocab_size = 30522  # Match bert vocab size
-            sequence_length = 32
-            size = 16
-            batch_size = 8
-
-            train_dataset = RandomTextClassificationDataset(size=size,
-                                                            vocab_size=vocab_size,
-                                                            sequence_length=sequence_length,
-                                                            num_classes=2,
-                                                            use_keys=True)
-
-            train_dataloader = DataLoader(train_dataset, batch_size=batch_size)
-
-            trainer = Trainer(model=model,
-                                train_dataloader=train_dataloader,
-                                max_duration='1ep',
-                                save_folder='./',
-                                save_interval='1ep',
-                                save_filename='hf-checkpoint.pt')
-
+            composer_model = HuggingFaceModel(hf_model, tokenizer=hf_tokenizer, metrics=[], use_logits=True)
+            trainer = Trainer(model=composer_model,
+                              train_dataloader=train_dataloader,
+                              save_filename='hf-checkpoint.pt',
+                              max_duration='1ep',
+                              save_folder='./')
             trainer.fit()
             trainer.close()
 
-
-        .. testcode:: composer.models.huggingface.HuggingFaceModel.hf_from_composer_checkpoint
+        .. testcode::hf_from_composer_checkpoint
 
             hf_model, hf_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint('hf-checkpoint.pt')
             composer_model = HuggingFaceModel(hf_model, hf_tokenizer)
-            trainer = Trainer(..., model=composer_model)
+            trainer = Trainer(model=composer_model,
+                              train_dataloader=train_dataloader,
+                              save_filename='hf-checkpoint.pt',
+                              max_duration='1ep',
+                              save_folder='./')
 
         Args:
             checkpoint_path (str): Path to the composer checkpoint, can be a local path, http(s):// url, or s3:// uri

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -37,7 +37,7 @@ class HuggingFaceModel(ComposerModel):
         model (transformers.PreTrainedModel): A 🤗 Transformers model.
         tokenizer (transformers.PreTrainedTokenizer, optional): The tokenizer used to prepare the dataset. Default ``None``.
                                                                 Note: If the tokenizer is provided, its config will be saved in the composer checkpoint, and it can be reloaded
-                                                                using ``HuggingFaceModel.hf_from_composer_checkpoint``. If the tokenizer is not provided here, it will not be saved in the composer checkpoint.
+                                                                using :meth:`HuggingFaceModel.hf_from_composer_checkpoint`. If the tokenizer is not provided here, it will not be saved in the composer checkpoint.
         use_logits (bool, optional): If True, the model's output logits will be used to calculate validation metrics. Else, metrics will be inferred from the HuggingFaceModel directly. Default: ``False``
         metrics (list[Metric], optional): list of torchmetrics to apply to the output of `validate`. Default: ``None``.
     .. warning:: This wrapper is designed to work with 🤗 datasets that define a `labels` column.
@@ -140,21 +140,21 @@ class HuggingFaceModel(ComposerModel):
                               save_folder='./')
 
         Args:
-            checkpoint_path (str): Path to the composer checkpoint, can be a local path, http(s):// url, or s3:// uri
+            checkpoint_path (str): Path to the composer checkpoint, can be a local path, ``http(s)://`` url, or ``s3://`` uri
             model_instantiation_class (Union[Type[:class:`transformers.PreTrainedModel`], Type[:class:`transformers.AutoModel`]]), optional):
-                Class to use to create the huggingface model. Defaults to the model class used to save the config. If this argument is
-                of type :class:`transformers.AutoModel, the `from_config` method will be used, while if it is of type :class:`transformers.PreTrainedModel`,
-                the constructor will be called.
+                Class to use to create the HuggingFace model. Defaults to the model class used in the original checkpoint. If this argument is
+                a HuggingFace auto class (e.g. :class:`transformers.AutoModel` or :class:`transformers.AutoModelForSequenceClassification`), the ``from_config`` method will be used,
+                while if it is of type :class:`transformers.PreTrainedModel`, the constructor will be called.
             model_init_kwargs: Dict[str, Any]: Extra arguments to pass in for the model creation (e.g. ``num_labels`` for creating a sequence classification model)
             local_checkpoint_save_location (Optional[Union[Path, str]], optional): If specified, where to save the checkpoint file to locally.
                                                                                    If the input ``checkpoint_path`` is already a local path, this will be a symlink.
                                                                                    Defaults to None, which will use a temporary file.
 
         Raises:
-            ValueError: If the ``model_instantiation_class``, or the model class saved in the checkpoint is not from the ``transformers`` module
+            ValueError: If the ``model_instantiation_class``, or the model class saved in the checkpoint, is not from the ``transformers`` module
 
         Returns:
-            Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]: The loaded huggingface model and (if present) tokenizer
+            Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]: The loaded HuggingFace model and (if present) tokenizer
         """
         import transformers
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -9,7 +9,6 @@ import json
 import logging
 import tempfile
 import textwrap
-import warnings
 from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
@@ -75,7 +74,7 @@ class HuggingFaceModel(ComposerModel):
         self.tokenizer = tokenizer
 
         if self.tokenizer is None:
-            warnings.warn(
+            log.warning(
                 'The tokenizer was not provided. This means the tokenizer config will not be saved in the checkpoint.')
 
         if tokenizer is not None and self.config.vocab_size != len(tokenizer):

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -104,9 +104,7 @@ class HuggingFaceModel(ComposerModel):
     ) -> Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]:
         """Loads a HuggingFace model (and tokenizer if present) from a composer checkpoint.
 
-        Example:
-
-        .. testsetup::hf_from_composer_checkpoint
+        .. testsetup::
 
             import torch
 
@@ -129,13 +127,15 @@ class HuggingFaceModel(ComposerModel):
             trainer.fit()
             trainer.close()
 
-        .. testcode::hf_from_composer_checkpoint
+        Example:
+
+        .. testcode::
 
             hf_model, hf_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint('hf-checkpoint.pt')
             composer_model = HuggingFaceModel(hf_model, hf_tokenizer)
             trainer = Trainer(model=composer_model,
                               train_dataloader=train_dataloader,
-                              save_filename='hf-checkpoint.pt',
+                              save_filename='hf-checkpoint-2.pt',
                               max_duration='1ep',
                               save_folder='./')
 

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -85,6 +85,7 @@ if sys.path[0] != _repo_root:
     sys.path.insert(0, _repo_root)
 
 from tests.common import SimpleModel
+from tests.common.datasets import RandomClassificationDataset
 
 # Disable wandb
 os.environ['WANDB_MODE'] = 'disabled'

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -85,7 +85,7 @@ if sys.path[0] != _repo_root:
     sys.path.insert(0, _repo_root)
 
 from tests.common import SimpleModel
-from tests.common.datasets import RandomClassificationDataset
+from tests.common.datasets import RandomTextClassificationDataset
 
 # Disable wandb
 os.environ['WANDB_MODE'] = 'disabled'

--- a/tests/common/datasets.py
+++ b/tests/common/datasets.py
@@ -168,3 +168,40 @@ class RandomTextClassificationDataset(torch.utils.data.Dataset):
             return {'input_ids': x, 'labels': y}
         else:
             return x, y
+
+
+class RandomTextLMDataset(torch.utils.data.Dataset):
+    """ Text classification dataset with values (just input token ids) drawn uniformly
+    Args:
+        vocab_size (int): vocab size to use (default: 10)
+        size (int): number of samples (default: 100)
+        sequence_length (int): sequence length to use, all sequences will be of this length with no padding (default: 8)
+        use_keys: (bool): whether to return the item in a dictionary with keys for input and output
+    """
+
+    def __init__(self, size: int = 100, vocab_size: int = 10, sequence_length: int = 8, use_keys: bool = False):
+        self.vocab_size = vocab_size
+        self.sequence_length = sequence_length
+        self.use_keys = use_keys
+
+        self.input_key = 'input_ids'
+
+        self.size = size
+        self.x = None
+        self.y = None
+
+        super().__init__()
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, index: int):
+        if self.x is None:
+            self.x = torch.randint(low=0, high=self.vocab_size, size=(self.size, self.sequence_length))
+
+        x = self.x[index]
+
+        if self.use_keys:
+            return {'input_ids': x}
+        else:
+            return x

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -117,6 +117,10 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     # the tokenizers are not usable below these pops
     tokenizer1.__dict__.pop('_tokenizer')
     tokenizer2.__dict__.pop('_tokenizer')
+
+    # extra key that is not important
+    tokenizer1.__dict__.pop('deprecation_warnings')
+    tokenizer2.__dict__.pop('deprecation_warnings')
     assert tokenizer1.__dict__ == tokenizer2.__dict__
 
 
@@ -225,7 +229,7 @@ def test_hf_state_dict_info(tmp_path: str, pass_in_tokenizer: bool, modify_token
 # @pytest.mark.parametrize('checkpoint_load_folder', ['checkpoints', 's3://checkpoints'])
 # @pytest.mark.parametrize('local_save_name', [None, 'local-checkpoint.pt'])
 def test_hf_loading_from_checkpoint(
-    tmp_path: str,
+    tmp_path: Path,
     # num_classes: int,
     pass_in_tokenizer: bool,
     # model_class: Optional[str],
@@ -287,4 +291,10 @@ def test_hf_loading_from_checkpoint(
                       progress_bar=True)
 
     trainer.fit()
+
+    hf_loaded_model, hf_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(
+        str(tmp_path / 'hf-checkpoint.pt'))
+
+    check_hf_model_equivalence(hf_loaded_model, hf_model)
+    check_hf_tokenizer_equivalence(hf_loaded_tokenizer, tokenizer)
     assert False


### PR DESCRIPTION
# What does this PR do?
This is the follow on PR to #1744, so you should look at that one first, but the changes here are accurate on top of that.

This PR adds support for loading a huggingface model and tokenizer from the information saved in the the composer checkpoint that is added by #1744.

TODO:
- [x] Add doctests
- [ ] Manual test with mosaic bert

# What issue(s) does this change relate to?
Design here: https://www.notion.so/Autoload-Huggingface-models-for-finetuning-59dda720b7ae4bee90d3594a5ab731d9
Closes: [CO-1109](https://mosaicml.atlassian.net/browse/CO-1109) and [CO-1110](https://mosaicml.atlassian.net/browse/CO-1110)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
